### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/com/javax0/djcproxy/ProxyFactory.java
+++ b/src/main/java/com/javax0/djcproxy/ProxyFactory.java
@@ -160,8 +160,10 @@ public class ProxyFactory<ClassToBeProxied> {
 		generatedClassName = sourceFactory.getGeneratedClassName();
 		Compiler compiler = new Compiler();
 		compiler.setClassLoader(calculateClassLoader(originalClass));
-		String classFQN = sourceFactory.getGeneratedPackageName() + "."
-				+ sourceFactory.getGeneratedClassName();
+
+		String packagePrefix =
+			sourceFactory.getGeneratedPackageName() == null ? "" : sourceFactory.getGeneratedPackageName() + ".";
+		String classFQN = packagePrefix + sourceFactory.getGeneratedClassName();
 		Class<?> proxyClass = compiler.compile(source, classFQN);
 		compilerErrorOutput = compiler.getCompilerErrorOutput();
 		if (proxyClass == null) {

--- a/src/main/java/com/javax0/djcproxy/ProxySourceFactory.java
+++ b/src/main/java/com/javax0/djcproxy/ProxySourceFactory.java
@@ -44,6 +44,10 @@ class ProxySourceFactory<Proxy> {
 	}
 
 	private void calculatePackageName(Package originalPackage) {
+		if (originalPackage == null) {
+			return;
+		}
+
 		String originalPackageName = originalPackage.getName();
 		final String[] forbiddenPackages = new String[] { "java.", "javax." };
 		for (String prefix : forbiddenPackages) {

--- a/src/test/java/ProxyFactoryWithDefaultPackageTest.java
+++ b/src/test/java/ProxyFactoryWithDefaultPackageTest.java
@@ -1,0 +1,36 @@
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import com.javax0.djcproxy.MethodInterceptor;
+import com.javax0.djcproxy.MethodProxy;
+import com.javax0.djcproxy.ProxyFactory;
+
+
+public class ProxyFactoryWithDefaultPackageTest {
+
+	public static class DefaultPackageClass {
+		String foo() {
+			return "foo";
+		}
+	}
+
+	private class Interceptor implements MethodInterceptor {
+		@Override
+		public Object intercept(Object obj, Method method, Object[] args, MethodProxy mproxy) throws Throwable {
+			return method.invoke(args);
+		}
+	}
+
+	@Test
+	public void given_ObjectWithDefaultPackage_then_compileWithoutExceptions() throws Exception {
+		DefaultPackageClass realObject = new DefaultPackageClass();
+
+		ProxyFactory<DefaultPackageClass> factory = new ProxyFactory<>();
+		DefaultPackageClass proxy = factory.create(realObject, new Interceptor());
+
+		assertEquals("foo", proxy.foo());
+	}
+}


### PR DESCRIPTION
Fix NPE when use the default-package.

Example:
```java
import com.javax0.djcproxy.ProxyFactory;

public class SimpleProxy {
    public static class SmallObject {
        void foo() {
            System.out.println("Foo");
        }
    }

    public static void main(String[] args) throws Exception {
        SmallObject so = new SmallObject();

        ProxyFactory<SmallObject> factory = new ProxyFactory<>();
        SmallObject proxy = factory.create(so, (o, method, objects, methodProxy) -> {
            System.out.println("Proxy invoke");
           return method.invoke(so, objects);
        });
    }
    
}
```

Output:
```
Exception in thread "main" java.lang.NullPointerException
	at com.javax0.djcproxy.ProxySourceFactory.calculatePackageName(ProxySourceFactory.java:47)
	at com.javax0.djcproxy.ProxySourceFactory.create(ProxySourceFactory.java:64)
	at com.javax0.djcproxy.ProxyFactory.createClass(ProxyFactory.java:159)
	at com.javax0.djcproxy.ProxyFactory.create(ProxyFactory.java:133)
	at SimpleProxy.main(SimpleProxy.java:19)
```